### PR TITLE
Add missing -f option to getopt option string

### DIFF
--- a/audio2tap.c
+++ b/audio2tap.c
@@ -93,7 +93,7 @@ int main(int argc, char** argv){
     exit(1);
   }
   
-  while( (option=getopt_long(argc,argv,"d:H:0ihVc:nw:t:",cmdline,NULL)) != -1){
+  while( (option=getopt_long(argc,argv,"d:H:0ihVc:nf:t:",cmdline,NULL)) != -1){
     switch(option){
     case 'c':
       if(!strcmp(optarg,"c64"))


### PR DESCRIPTION
As reported here (german): https://www.forum64.de/index.php?thread/107434-audio2tap-exe-flag-f%C3%BCr-frequenz-funktioniert-nicht/

The short '-f' option to set the frequency did not work in audio2tap, as it wasn't present in the getopt options string. (Maybe it does work with some versions of getopt, if they automatically add short options referenced from the long options, but that isn't the case with my version (glibc 2.32) and apparently the same is true for the original reporter).

I replaced the 'w' short option character which was added with cd02d50c but wasn't used.